### PR TITLE
added Dockerfiles for avr-gcc8 and avr-gcc12

### DIFF
--- a/tools/Docker/avr-gcc12/Dockerfile
+++ b/tools/Docker/avr-gcc12/Dockerfile
@@ -1,0 +1,8 @@
+FROM archlinux:base
+
+## update package cache and install some packages
+RUN pacman -Sy && pacman -S --noconfirm sudo git base-devel avr-gcc avr-libc
+
+VOLUME "/opt/src"
+WORKDIR "/opt/src"
+CMD ["/bin/bash"]

--- a/tools/Docker/avr-gcc12/README.md
+++ b/tools/Docker/avr-gcc12/README.md
@@ -1,0 +1,19 @@
+# AVR-GCC 12.x
+
+this is a Dockerfile to build Arch Linux with `avr-gcc` compiler version 12.x
+
+## Create Docker Container
+
+```
+docker build -t avr-gcc12 .
+```
+
+## Compile code
+
+open terminal in root folder of the project and type:
+```
+docker run -it --rm -v "$PWD":/opt/src avr-gcc12 bash
+[root@f86d24d031d3 src]# ls
+boot.c  boot.eep  boot.hex  bootnew.hex  build  burn.sh  crt1.S  devs  docs  libs  LICENSE  main.c  main.hex  make.sh  MODBUS.md  README.md  tools
+[root@f86d24d031d3 src]# ./make.sh 
+```

--- a/tools/Docker/avr-gcc8/Dockerfile
+++ b/tools/Docker/avr-gcc8/Dockerfile
@@ -1,0 +1,27 @@
+FROM archlinux:base
+
+## update package cache and install some packages
+RUN pacman -Sy && pacman -S --noconfirm sudo git base-devel avr-gcc avr-libc
+
+## need to create build user for makepkg because it cannot run as root..
+RUN useradd --no-create-home --shell=/bin/false build && usermod -L build
+RUN echo "build ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+RUN echo "root ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+WORKDIR "/opt/avr"
+
+## get PKGBUILD of downgrade script, build and install it
+RUN git clone https://aur.archlinux.org/downgrade.git 
+RUN chown build:root downgrade/* downgrade/.*
+RUN cd downgrade && sudo -u build makepkg -si --noconfirm
+
+## disable question if package should be added to ignore list and assume yes as answer
+RUN sed -i 's/^      eval_gettext "add /      #eval_gettext "add /' /usr/sbin/downgrade
+RUN sed -i 's/^      read -r ans/      #read -r ans\n      ans=y/' /usr/sbin/downgrade
+
+## finaly downgrade avr-gcc to 8 branch
+RUN downgrade 'avr-gcc=8.3.0' -- --noconfirm
+
+VOLUME "/opt/src"
+WORKDIR "/opt/src"
+CMD ["/bin/bash"]

--- a/tools/Docker/avr-gcc8/README.md
+++ b/tools/Docker/avr-gcc8/README.md
@@ -1,0 +1,21 @@
+# AVR-GCC 8.x
+
+to compile the tinymodbus project you have to use an old `avr-gcc` because of space requirements.
+
+this is a Dockerfile to build Arch Linux with `avr-gcc` compiler version 8.3
+
+## Create Docker Container
+
+```
+docker build -t avr-gcc8 .
+```
+
+## Compile code
+
+open terminal in root folder of the project and type:
+```
+docker run -it --rm -v "$PWD":/opt/src avr-gcc8 bash
+[root@f86d24d031d3 src]# ls
+boot.c  boot.eep  boot.hex  bootnew.hex  build  burn.sh  crt1.S  devs  docs  libs  LICENSE  main.c  main.hex  make.sh  MODBUS.md  README.md  tools
+[root@f86d24d031d3 src]# ./make.sh 
+```


### PR DESCRIPTION
It is not easy to get hands on an old avr-gcc8 compiler.
thats why i created a Dockerfile with a working avr-gcc version 8.3 including a README.md on how to use it.
I also added a Dockerfile for a recent avr-gcc12 for comparison reasons with v8.3