### PR TITLE
Update MODBUS.md

### DIFF
--- a/MODBUS.md
+++ b/MODBUS.md
@@ -36,6 +36,9 @@
   | 0x1211 (2 regs) | 4 byte (float)    | I2C: Read ultraviolet index from SI1145 device (Index)     |
   | 0x1230 (2 regs) | 4 byte (float)    | I2C: Read temperature from BMP280 device (Celsius)         |
   | 0x1231 (2 regs) | 4 byte (float)    | I2C: Read air pressure from BMP280 device (hPa)            |
+  | 0x1240 (2 regs) | 4 byte (float)    | I2C: Read temperature from BME280 device (Celsius)         |
+  | 0x1241 (2 regs) | 4 byte (float)    | I2C: Read air pressure from BME280 device (hPa)            |
+  | 0x1242 (2 regs) | 4 byte (float)    | I2C: Read air pressure from BME280 device (RH)             |
 
   **Write Registers (0x06)**
 


### PR DESCRIPTION
I have added the Modbus registers for the BME280 to the table. According to i2c-read they are 1240,1241 and 1242